### PR TITLE
Tmux 에서 neovim 사용이 가능하도록 변경

### DIFF
--- a/lua/core/keymaps.lua
+++ b/lua/core/keymaps.lua
@@ -1,7 +1,3 @@
--- Clipboard keymaps
-vim.keymap.set({ "n", "v" }, "<M-c>", '"+y')
-vim.keymap.set("t", "<M-v>", [[<C-\><C-n>"+pi]]) -- for paste bug in sidekick terminal by <D-v> paste
-
 vim.keymap.set("n", "<M-s>", "<cmd>w<CR>", { desc = "Save current file" })
 vim.keymap.set("n", "<M-a>", "ggVG", { desc = "Select all lines" })
 
@@ -9,7 +5,7 @@ vim.keymap.set("n", "<C-q>", "<C-6>", { desc = "Switch to last accessed buffer" 
 vim.keymap.set("n", "<C-6>", "<Nop>")
 
 vim.keymap.set("n", "<leader>rq", ":cexpr [] | cclose<CR>", { desc = "Reset and close quick-fix" })
--- vim.keymap.set("t", "<Esc>", [[<C-\><C-n>]], { noremap = true, desc = "change to normal mode" })
+vim.keymap.set("t", "<C-]>", [[<C-\><C-n>]], { noremap = true, desc = "change to normal mode" })
 
 vim.keymap.set("n", "<leader>[[", "<cmd>qa!<CR>", { desc = "Exit neovim by force" })
 

--- a/lua/plugins/navigation/nvim-tree.lua
+++ b/lua/plugins/navigation/nvim-tree.lua
@@ -48,10 +48,8 @@ return {
   dependencies = "nvim-tree/nvim-web-devicons",
   cmd = { "NvimTreeToggle", "NvimTreeOpen" },
   keys = {
-    { "<D-e>", toggle_focus_tree, mode = { "n", "v" }, desc = "Toggle focus nvim tree" },
-    { "<M-e>", toggle_focus_tree, mode = { "n", "v" }, desc = "Toggle focus nvim tree" },
-    { "<D-b>", toggle_tree_keep_focus, mode = { "n", "v" }, desc = "Toggle nvim tree" },
-    { "<M-b>", toggle_tree_keep_focus, mode = { "n", "v" }, desc = "Toggle nvim tree" },
+    { "<leader>ee", toggle_focus_tree, mode = { "n", "v" }, desc = "Toggle focus nvim tree" },
+    { "<leader>bb", toggle_tree_keep_focus, mode = { "n", "v" }, desc = "Toggle nvim tree" },
     { "<leader>e1", set_tree_width(42), desc = "NvimTree width 42" },
     { "<leader>e2", set_tree_width(50), desc = "NvimTree width 50" },
     { "<leader>e3", set_tree_width(60), desc = "NvimTree width 60" },

--- a/lua/plugins/navigation/telescope.lua
+++ b/lua/plugins/navigation/telescope.lua
@@ -142,9 +142,7 @@ return {
     pcall(telescope.load_extension, "frecency")
     pcall(telescope.load_extension, "file_browser")
 
-    keymap.set("n", "<D-p>", builtin.find_files, { desc = "Telescope find files" })
-    keymap.set("n", "<M-p>", builtin.find_files, { desc = "Telescope find files" })
-
+    keymap.set("n", "<leader>ff", builtin.find_files, { desc = "Telescope find files" })
     keymap.set("n", "<leader>fr", builtin.resume, { desc = "Telescope resume last picker" })
     keymap.set("n", "<leader>fl", builtin.live_grep, { desc = "Telescope live grep" })
 

--- a/lua/plugins/ui/bufferline.lua
+++ b/lua/plugins/ui/bufferline.lua
@@ -32,8 +32,8 @@ return {
       highlights = highlights,
     })
 
-    vim.keymap.set("n", "<D-H>", "<cmd>BufferLineCyclePrev<CR>", { desc = "Go to prev buffer" })
-    vim.keymap.set("n", "<D-L>", "<cmd>BufferLineCycleNext<CR>", { desc = "Go to next buffer" })
+    vim.keymap.set("n", "<M-H>", "<cmd>BufferLineCyclePrev<CR>", { desc = "Go to prev buffer" })
+    vim.keymap.set("n", "<M-L>", "<cmd>BufferLineCycleNext<CR>", { desc = "Go to next buffer" })
 
     local function close_buffer()
       local current_buf = vim.api.nvim_get_current_buf()

--- a/lua/plugins/workflow/toggleterm.lua
+++ b/lua/plugins/workflow/toggleterm.lua
@@ -78,7 +78,8 @@ return {
       term:toggle()
     end
 
-    vim.keymap.set({ "n", "t" }, "<D-g>", toggle_tmux_session, { desc = "Toggle tmux session in toggleterm" })
+    -- override default C-g keymap
+    vim.keymap.set({ "n", "t" }, "<C-g>", toggle_tmux_session, { desc = "Toggle tmux session in toggleterm" })
 
     vim.api.nvim_create_autocmd("FileType", {
       pattern = "rust",


### PR DESCRIPTION
1. Command, Meta 단축키 최소화
가급적 <leader> 단축키를 활용하도록 변경

2. Command 단축키를 Meta 단축키로 통일
터미널 설정에서 command -> meta escape 처리

### 추가 작업

- tmux.conf 설정
- ghostty config 설정

https://github.com/yurjune/dotfiles/commit/4800e53ea79c8ce9ce28946a3737229d0e43f4de