### PR TITLE
im-select 를 hammerspoon 으로 교체

### DIFF
--- a/lua/etc/switch-input-on-buf.lua
+++ b/lua/etc/switch-input-on-buf.lua
@@ -1,15 +1,18 @@
 -- Switch input source when leave or enter specific buffer
+-- Needs specific config in Hammerspoon
 
--- check input-source name by 'im-select' command in terminal
-local en_source = "com.apple.keylayout.ABC"
--- local ko_source = "com.apple.inputmethod.Korean.2SetKorean"   -- macOS default Korean(두벌식)
--- local ko_source = "org.youknowone.inputmethod.Gureum.han2" -- 구름 입력기(두벌식)
+local hs_cli = "/usr/local/bin/hs"
+local hs_module = "nvimInputSource"
 
-local function set_input_source_async(im)
-  if not im or im == "" then
-    return
-  end
-  vim.fn.jobstart("im-select " .. im)
+local function call_hammerspoon(method)
+  local command = hs_module .. "." .. method .. "()" -- ex) nvimInputSource.switchToEnglish()
+  vim.fn.jobstart({
+    hs_cli,
+    "-c",
+    command,
+  }, {
+    detach = true, -- prevent killing hs process when exit
+  })
 end
 
 local augroup = vim.api.nvim_create_augroup("SwitchInputOnBuf", { clear = true })
@@ -18,6 +21,6 @@ vim.api.nvim_create_autocmd("BufLeave", {
   group = augroup,
   pattern = vim.g.sidekick_buf_pattern,
   callback = function()
-    set_input_source_async(en_source)
+    call_hammerspoon("switchToEnglish")
   end,
 })

--- a/lua/etc/switch-input-on-insert.lua
+++ b/lua/etc/switch-input-on-insert.lua
@@ -1,51 +1,36 @@
 -- Switch input source when leave or enter insert mode
+-- Needs specific config in Hammerspoon
 
-local last_input_source = nil
-local en_input_source = "com.apple.keylayout.ABC"
+local hs_cli = "/usr/local/bin/hs"
+local hs_module = "nvimInputSource"
 
-local function get_input_source_async(callback)
-  vim.fn.jobstart("im-select", {
-    on_stdout = function(_, data)
-      if data and data[1] then
-        local im = vim.fn.trim(data[1])
-        callback(im)
-      end
-    end,
-    stdout_buffered = true,
+local function call_hammerspoon(method)
+  local command = hs_module .. "." .. method .. "()" -- ex) nvimInputSource.enterInsert()
+  vim.fn.jobstart({
+    hs_cli,
+    "-c",
+    command,
+  }, {
+    detach = true, -- prevent killing hs process when exit
   })
-end
-
-local function set_input_source_async(im)
-  if not im or im == "" then
-    return
-  end
-  vim.fn.jobstart("im-select " .. im)
 end
 
 local augroup = vim.api.nvim_create_augroup("SwitchInputOnInsert", { clear = true })
 
--- save current input source change change source to EN when leave insert mode
 vim.api.nvim_create_autocmd("InsertLeave", {
   group = augroup,
   pattern = "*",
+  desc = "Save input source and switch to English",
   callback = function()
-    get_input_source_async(function(im)
-      if im and im ~= "" then
-        last_input_source = im
-      end
-    end)
-
-    set_input_source_async(en_input_source)
+    call_hammerspoon("leaveInsert")
   end,
 })
 
--- restore last input source when enter insert mode
 vim.api.nvim_create_autocmd("InsertEnter", {
   group = augroup,
   pattern = "*",
+  desc = "Restore saved input source",
   callback = function()
-    if last_input_source and last_input_source ~= "" and last_input_source ~= en_input_source then
-      set_input_source_async(last_input_source)
-    end
+    call_hammerspoon("enterInsert")
   end,
 })


### PR DESCRIPTION
특정 neovim 이벤트에 input source 를 교체할 때 사용하던 im-select 의존성을 hammerspoon 설정으로 교체합니다.

ref. [c09237f19157ee81b206e1b2fa89323613751f93](https://github.com/yurjune/dotfiles/commit/c09237f19157ee81b206e1b2fa89323613751f93)